### PR TITLE
init_session() needs to be called no matter if the connection object …

### DIFF
--- a/pynYNAB/ClientFactory.py
+++ b/pynYNAB/ClientFactory.py
@@ -68,10 +68,10 @@ class nYnabClientFactory(object):
                     if not hasattr(args, 'password') or args.password is None:
                         raise NoCredentialsException
                 connection = nYnabConnection(args.email, args.password)
-                connection.init_session()
             else:
                 connection = args.connection
 
+            connection.init_session()
             client_id = connection.id
 
             def postprocessed_client(cl):

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -11,6 +11,9 @@ class MockConnection(object):
     def __init__(self,id):
         self.id = id
 
+    def init_session(self):
+        pass
+
 
 class Args(object):
     budget_name = 'Test Budget'

--- a/tests/tests_operations.py
+++ b/tests/tests_operations.py
@@ -25,6 +25,8 @@ date_format = dict(
 class MockConnection2(object):
     id='12345'
 
+    def init_session(self): pass
+
 factory = nYnabClientFactory('sqlite://')
 
 
@@ -37,6 +39,8 @@ class TestOperations(TestCommonMock):
                 self.assertEqual(request_dic['date_format'], json.dumps(date_format))
             user_id = '1234'
             id = '1234'
+
+            def init_session(self): pass
 
         self.client = factory.create_client(budgetname='', nynabconnection=MockConnection2(), sync=False)
         self.client.create_budget(budget_name='New Budget')


### PR DESCRIPTION
…is given to the factory or if it is created there.

Otherwise something like this fails:

```
from pynYNAB.ClientFactory import nYnabClientFactory
from pynYNAB.connection import nYnabConnection
from  pynYNAB.schema.budget import Payee
class Arg(object): pass
args = Arg()
args.budgetname = 'a'
args.email = 'b'
args.password = 'c'
import logging
logging.basicConfig(level='DEBUG')
log = logging.getLogger(__name__)

connection = nYnabConnection(args.email, args.password)
client = nYnabClientFactory().create_client(budgetname=args.budgetname,
                                                      nynabconnection=connection,
                                                      sync=True,
                                                      logger=log)
```